### PR TITLE
Update TechJobsOO.Tests project file to copy .txt files to output directory

### DIFF
--- a/TechJobsOO.Tests/TechJobsOO.Tests.csproj
+++ b/TechJobsOO.Tests/TechJobsOO.Tests.csproj
@@ -19,4 +19,13 @@
     <ProjectReference Include="..\TechJobsOOAutoGraded6\TechJobsOOAutoGraded6.csproj" />
     <ProjectReference Include="..\TechJobs.Test\TechJobs.Tests.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="EmptyFieldTest.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="StartsAndEndsWithNewLine.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Some of the TechJobsOO.Tests tests fail on build because the EmptyFieldTest.txt and StartsAndEndsWithNewLine.txt files do not copy to the output directory.