### PR TITLE
Fixes for false negatives on Task 5 tests

### DIFF
--- a/TechJobsOO.Tests/TestTask5.cs
+++ b/TechJobsOO.Tests/TestTask5.cs
@@ -1,6 +1,4 @@
-﻿
-using System.Diagnostics.Metrics;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using TechJobs.Tests;
 
 namespace TechJobsOO.Tests
@@ -12,7 +10,7 @@ namespace TechJobsOO.Tests
         //Uses jobs from the Job class.
         //Tests are numbered.
 
-        /*TODO: Task 5: Remove this line to uncomment the test
+        /*TODO: Task 5: Remove this line to uncomment the tests
 
         //Unit Test 1:  TestToStringStartsAndEndsWithNewLine  -----------------------
 
@@ -105,11 +103,7 @@ namespace TechJobsOO.Tests
             var output = stringWriter.ToString();
 
             //verify
-            Assert.IsTrue(output.Contains("Name: Product tester"));
-            Assert.IsTrue(output.Contains("Employer: ACME"));
-            Assert.IsTrue(output.Contains("Location: Desert"));
-            Assert.IsTrue(output.Contains("Position Type: Quality control"));
-            Assert.IsTrue(output.Contains("Core Competency: Persistence"));
+            Assert.IsTrue(output.Contains($"Name: Product tester") && output.Contains("Employer: ACME") && output.Contains("Location: Desert") && output.Contains("Position Type: Quality control") && output.Contains("Core Competency: Persistence"));
 
         }
 

--- a/TechJobsOO.Tests/TestTask5.cs
+++ b/TechJobsOO.Tests/TestTask5.cs
@@ -1,4 +1,8 @@
 ﻿
+using System.Diagnostics.Metrics;
+using System.Text.RegularExpressions;
+using TechJobs.Tests;
+
 namespace TechJobsOO.Tests
 {
 	[TestClass]
@@ -8,7 +12,7 @@ namespace TechJobsOO.Tests
         //Uses jobs from the Job class.
         //Tests are numbered.
 
-        /*TODO: Task 5: Remove this line to uncomment the tests
+        /*TODO: Task 5: Remove this line to uncomment the test
 
         //Unit Test 1:  TestToStringStartsAndEndsWithNewLine  -----------------------
 
@@ -37,23 +41,26 @@ namespace TechJobsOO.Tests
             Assert.AreEqual("true", existsCheck, "'TestToStringStartsAndEndsWithNewLine' not created");
         }
 
-
         [TestMethod]  //2
         public void Test_TestToString_Starts_And_Ends_With_NewLine()
         {
             //comparing output to a text file.
-            //id numbers may get a little wonky
 
             //setup
-            string text = System.IO.File.ReadAllText("StartsAndEndsWithNewLine.txt").ToString();
+            string fromFile = File.ReadAllText("StartsAndEndsWithNewLine.txt").ToString();
+
             var stringWriter = new StringWriter();
             Console.SetOut(stringWriter);
             var job = new RunTechJobs();
             job.RunProgram();
-            var output = stringWriter.ToString();
+            string rawOutput = stringWriter.ToString();
+
+            string comparisonText = StandardizeLineBreaks(fromFile);
+            string correctedOutput = StandardizeLineBreaks(rawOutput);
+            string expected = SyncOutputTestIdNumbers(comparisonText, correctedOutput);
 
             //verify
-            Assert.AreEqual(text, output, "New Line issue");
+            Assert.AreEqual(expected, correctedOutput, "New Line issue");
         }
 
         //Unit Test 2: TestToStringContainsCorrectLabelsAndData -----------------------
@@ -98,7 +105,12 @@ namespace TechJobsOO.Tests
             var output = stringWriter.ToString();
 
             //verify
-            Assert.IsTrue(output.Contains($"Name: Product tester") && output.Contains("Employer: ACME") && output.Contains("Location: Desert") && output.Contains("Position Type: Quality control") && output.Contains("Core Competency: Persistence"));
+            Assert.IsTrue(output.Contains("Name: Product tester"));
+            Assert.IsTrue(output.Contains("Employer: ACME"));
+            Assert.IsTrue(output.Contains("Location: Desert"));
+            Assert.IsTrue(output.Contains("Position Type: Quality control"));
+            Assert.IsTrue(output.Contains("Core Competency: Persistence"));
+
         }
 
 
@@ -133,20 +145,49 @@ namespace TechJobsOO.Tests
         public void Test_TestToStringHandlesEmptyField()
         {
             //comparing output to a text file.
-            //id numbers may get a little wonky
 
-            string text = System.IO.File.ReadAllText("EmptyFieldTest.txt").ToString();
+            string fromFile = File.ReadAllText("EmptyFieldTest.txt").ToString();
+
             var stringWriter = new StringWriter();
             Console.SetOut(stringWriter);
             var job = new RunTechJobs();
             job.RunProgram();
-            var output = stringWriter.ToString();
+            var rawOutput = stringWriter.ToString();
+
+            string comparisonText = StandardizeLineBreaks(fromFile);
+            string correctedOutput = StandardizeLineBreaks(rawOutput);
+            string expected = SyncOutputTestIdNumbers(comparisonText, correctedOutput);
 
             //verify
-            Assert.AreEqual(text, output, "Empty string handling error");
+            Assert.AreEqual(expected, correctedOutput, "Empty string handling error");
         }
-        TODO: Task 5: Remove this line to uncomment the tests*/
 
+        private string SyncOutputTestIdNumbers(string target, string source)
+        {
+            int startId = GetConsoleOutputStartId(source) - 1;
+            const string pattern = @"ID: \d+";
+            return Regex.Replace(target, pattern, delegate (Match m)
+            {
+                startId++;
+                return $"ID: {startId}";
+            });
+        }
+
+        private int GetConsoleOutputStartId(string consoleOutput)
+        {
+            const string pattern = @"(?:ID: )(\d+)";
+            Match match = Regex.Match(consoleOutput, pattern);
+            return match.Success ? int.Parse(match.Groups[1].Value) : 1;
+        }
+
+        private string StandardizeLineBreaks(string text)
+        {
+            //Linux and modern Macs use \n, Windows uses \r\n, old Macs use \r
+            const string pattern = @"\r?\n|\r";
+            return Regex.Replace(text, pattern, Environment.NewLine);
+        }
+        
+        TODO: Task 5: Remove this line to uncomment the tests*/
     }
 
 }


### PR DESCRIPTION
Two of the autograder tests in Task 5 fail due to different newlines and/or a mismatch between the Id's in the console output and the text file.  This fixes both during the setup phase of those tests by...

1) Doing a pass over both the console output and the text from file to standardize the line breaks.
2) Reading the first Id from the console output, then replacing the Id's in the comparison text with sequential numbers starting from that value.